### PR TITLE
Add a general consolidated websocket for both headers and peer channe…

### DIFF
--- a/esv_client/client.py
+++ b/esv_client/client.py
@@ -18,8 +18,8 @@ from esv_reference_server.errors import Error
 
 SERVER_HOST = '127.0.0.1'
 SERVER_PORT = 47124
-WS_URL_HEADERS = f"http://localhost:{SERVER_PORT}/api/v1/headers/tips/websocket"
-WS_URL_TEMPLATE_MSG_BOX = "http://localhost:47124/api/v1/channel/{channelid}/notify"
+WS_URL_HEADERS = f"ws://localhost:{SERVER_PORT}/api/v1/headers/tips/websocket"
+WS_URL_TEMPLATE_MSG_BOX = "ws://localhost:47124/api/v1/channel/{channelid}/notify"
 
 
 class MockApplicationState:

--- a/esv_reference_server/errors.py
+++ b/esv_reference_server/errors.py
@@ -9,6 +9,10 @@ from aiohttp.web_exceptions import HTTPForbidden, HTTPBadRequest, HTTPConflict
 from esv_reference_server.types import WebsocketError
 
 
+class WebsocketUnauthorizedException(Exception):
+    pass
+
+
 class Error(Exception):
 
     def __init__(self, reason: str, status: int):

--- a/esv_reference_server/handlers_headers.py
+++ b/esv_reference_server/handlers_headers.py
@@ -3,14 +3,10 @@ import uuid
 
 import aiohttp
 import typing
-from aiohttp import web, WSServerHandshakeError, WebSocketError
-from aiohttp.client_exceptions import RequestInfo
+from aiohttp import web
 from aiohttp.web_ws import WebSocketResponse
-from multidict import CIMultiDictProxy
 
 from esv_reference_server.errors import Error
-from esv_reference_server.msg_box.controller import _try_read_bearer_token, _auth_ok
-from esv_reference_server.sqlite_db import SQLiteDatabase
 from esv_reference_server.types import HeadersWSClient
 
 if typing.TYPE_CHECKING:

--- a/esv_reference_server/handlers_headers.py
+++ b/esv_reference_server/handlers_headers.py
@@ -3,10 +3,14 @@ import uuid
 
 import aiohttp
 import typing
-from aiohttp import web
+from aiohttp import web, WSServerHandshakeError, WebSocketError
+from aiohttp.client_exceptions import RequestInfo
 from aiohttp.web_ws import WebSocketResponse
+from multidict import CIMultiDictProxy
 
 from esv_reference_server.errors import Error
+from esv_reference_server.msg_box.controller import _try_read_bearer_token, _auth_ok
+from esv_reference_server.sqlite_db import SQLiteDatabase
 from esv_reference_server.types import HeadersWSClient
 
 if typing.TYPE_CHECKING:
@@ -125,7 +129,7 @@ class HeadersWebSocket(web.View):
 
         try:
             client = HeadersWSClient(ws_id=ws_id, websocket=ws)
-            self.request.app['app_state'].add_ws_client(client)
+            self.request.app['app_state'].add_headers_ws_client(client)
             self.logger.debug('%s connected. host=%s.', client.ws_id, self.request.host)
             await self._handle_new_connection(client)
             return ws
@@ -139,36 +143,8 @@ class HeadersWebSocket(web.View):
                 if self.request.app['msg_box_ws_clients'].get(ws_id):
                     del self.request.app['msg_box_ws_clients'][ws_id]
 
-    async def _send_chain_tip(self, client: HeadersWSClient) -> None:
-        """Called once on initial connection"""
-        client_session: aiohttp.ClientSession = self.request.app['client_session']
-        app_state = self.request.app['app_state']
-        try:
-            request_headers = {'Accept': 'application/json'}
-            url_to_fetch = f"{app_state.header_sv_url}/api/v1/chain/tips"
-            async with client_session.get(url_to_fetch, headers=request_headers) as response:
-                result = await response.json()
-                for tip in result:
-                    if tip['state'] == "LONGEST_CHAIN":
-                        longest_chain_tip = tip
-                        current_best_hash = longest_chain_tip['header']['hash']
-                        current_best_height = longest_chain_tip['height']
-
-            request_headers = {'Accept': 'application/json'}
-            url_to_fetch = f"{app_state.header_sv_url}/api/v1/chain/header/{current_best_hash}"
-            async with client_session.get(url_to_fetch, headers=request_headers) as response:
-                result = await response.json()
-                self.logger.debug(f"Sending tip to new websocket connection, ws_id: {client.ws_id}")
-                await client.websocket.send_json(result)
-        except aiohttp.ClientConnectorError as e:
-            # When HeaderSV comes back online there will be a compensating chain tip notification
-            self.logger.error(f"HeaderSV service is unavailable on {app_state.header_sv_url}")
-            raise Error(reason=f"HeaderSV service is unavailable on {app_state.header_sv_url}",
-                        status=503)
-
     async def _handle_new_connection(self, client: HeadersWSClient) -> None:
         self.ws_clients = self.request.app['headers_ws_clients']
-        await self._send_chain_tip(client)
 
         async for msg in client.websocket:
             # Ignore all messages from client

--- a/esv_reference_server/msg_box/models.py
+++ b/esv_reference_server/msg_box/models.py
@@ -4,7 +4,7 @@ Distributed under the Open BSV software license, see the accompanying file LICEN
 """
 from dataclasses import dataclass
 from datetime import datetime
-from typing import NamedTuple, Optional, TypedDict, List
+from typing import NamedTuple, Optional, List
 
 
 @dataclass()

--- a/esv_reference_server/msg_box/models.py
+++ b/esv_reference_server/msg_box/models.py
@@ -76,9 +76,3 @@ class MessageMetadata(NamedTuple):
     msg_box_api_token_id: int
     content_type: str
     received_ts: datetime
-
-
-class PushNotification(TypedDict):
-    channel_id: MsgBox
-    notification: str
-    received: datetime

--- a/esv_reference_server/types.py
+++ b/esv_reference_server/types.py
@@ -1,6 +1,13 @@
-from typing import NamedTuple, TypedDict
+from datetime import datetime
+from typing import NamedTuple, TypedDict, Union
 
 from aiohttp import web
+
+
+class GeneralWSClient(NamedTuple):
+    ws_id: str
+    websocket: web.WebSocketResponse
+    accept_type: str  # application/json or application/octet-stream
 
 
 class HeadersWSClient(NamedTuple):
@@ -12,7 +19,6 @@ class MsgBoxWSClient(NamedTuple):
     ws_id: str
     websocket: web.WebSocketResponse
     msg_box_internal_id: int
-    accept_type: str  # http 'Accept' header (i.e. application/json vs application/octet-stream)
 
 
 class Route(NamedTuple):
@@ -29,3 +35,36 @@ class EndpointInfo(NamedTuple):
     http_method: str
     url: str
     auth_required: bool
+
+
+class Header(TypedDict):
+    hash: str
+    version: int
+    prevBlockHash: str
+    merkleRoot: str
+    creationTimestamp: int
+    difficultyTarget: int
+    nonce: int
+    transactionCount: int
+    work: int
+
+
+class PushNotification(TypedDict):
+    channel_id: int
+    notification: str
+    external_id: str  # general websocket needs this
+
+
+class TipNotification(TypedDict):
+    header: Header
+    state: str
+    chainWork: int
+    height: int
+
+
+class GeneralNotification(TypedDict):
+    message_type: str
+    result: Union[
+        PushNotification,
+        TipNotification
+    ]

--- a/esv_reference_server/types.py
+++ b/esv_reference_server/types.py
@@ -1,12 +1,16 @@
-from datetime import datetime
 from typing import NamedTuple, TypedDict, Union
 
+import typing
 from aiohttp import web
+
+if typing.TYPE_CHECKING:
+    from esv_reference_server.msg_box.models import MsgBox
 
 
 class GeneralWSClient(NamedTuple):
     ws_id: str
     websocket: web.WebSocketResponse
+    account_id: int
     accept_type: str  # application/json or application/octet-stream
 
 
@@ -50,9 +54,8 @@ class Header(TypedDict):
 
 
 class PushNotification(TypedDict):
-    channel_id: int
+    msg_box: 'MsgBox'
     notification: str
-    external_id: str  # general websocket needs this
 
 
 class TipNotification(TypedDict):
@@ -62,9 +65,14 @@ class TipNotification(TypedDict):
     height: int
 
 
+class ChannelNotification(TypedDict):
+    id: str
+    notification: str
+
+
 class GeneralNotification(TypedDict):
     message_type: str
     result: Union[
-        PushNotification,
-        TipNotification
+        TipNotification,
+        ChannelNotification
     ]

--- a/esv_reference_server/utils.py
+++ b/esv_reference_server/utils.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+import typing
+from aiohttp import web
+
+if typing.TYPE_CHECKING:
+    from esv_reference_server.sqlite_db import SQLiteDatabase
+
+
+def _try_read_bearer_token(request: web.Request) -> Optional[str]:
+    auth_string = request.headers.get('Authorization', None)
+    if auth_string is None or not auth_string.startswith("Bearer "):
+        return None
+    api_key = auth_string[7:]
+    return api_key
+
+
+def _try_read_bearer_token_from_query(request: web.Request) -> Optional[str]:
+    # No "Bearer " prefix
+    auth_string = request.query.get('token', None)
+    if auth_string is None:
+        return None
+    return auth_string
+
+
+def _auth_ok(api_key: str, db: 'SQLiteDatabase') -> bool:
+    account_id, _account_flags = db.get_account_id_for_api_key(api_key)
+    if account_id is None:
+        return False
+    return True

--- a/esv_reference_server/websock.py
+++ b/esv_reference_server/websock.py
@@ -1,0 +1,82 @@
+import logging
+import uuid
+
+import aiohttp
+from typing import Union
+import typing
+from aiohttp import web
+from aiohttp.web_ws import WebSocketResponse
+
+from esv_reference_server import errors
+from esv_reference_server.errors import Error
+from esv_reference_server.msg_box.controller import _auth_ok
+from esv_reference_server.sqlite_db import SQLiteDatabase
+from esv_reference_server.types import GeneralWSClient
+from esv_reference_server.utils import _try_read_bearer_token_from_query
+
+if typing.TYPE_CHECKING:
+    from esv_reference_server.server import ApplicationState
+
+
+class GeneralWebSocket(web.View):
+    """This is the general-purpose consolidated websocket. Protocol versioning is based
+    on the endpoint discovery apiVersion field. If the headers APIs are not listed then
+    there will be no tip notifications. The same applies to any future optional extension
+    APIs.
+
+    Requires a master bearer token as this authorizes for notifications from any peer channel
+    """
+
+    logger = logging.getLogger("general-websocket")
+
+    async def get(self) -> Union[WebSocketResponse, web.Response]:
+        """The communication for this is one-way - for message box notifications only.
+        Client messages will be ignored"""
+        app_state: 'ApplicationState' = self.request.app['app_state']
+        db: SQLiteDatabase = app_state.sqlite_db
+        accept_type = self.request.headers.get('Accept', 'application/json')
+        ws = None
+        ws_id = str(uuid.uuid4())
+
+        try:
+            # Note this bearer token is the channel-specific one
+            master_api_token = _try_read_bearer_token_from_query(self.request)
+            if not master_api_token:
+                raise Error(reason="Missing 'token' query parameter (requires master bearer token)",
+                            status=400)
+            if not _auth_ok(master_api_token, db):
+                raise Error(reason="Unauthorized - Invalid Token (example: ?token=t80Dp_dIk1kqkHK3P9R5cpDf67JfmNixNscexEYG0_xaCbYXKGNm4V_2HKr68ES5bytZ8F19IS0XbJlq41accQ==)",
+                            status=401)
+
+            ws = web.WebSocketResponse()
+            await ws.prepare(self.request)
+            client = GeneralWSClient(
+                ws_id=ws_id,
+                websocket=ws,
+                accept_type=accept_type
+            )
+            app_state.add_ws_client(client)
+            self.logger.debug('%s connected. host=%s. accept_type=%s',
+                              client.ws_id, self.request.host, accept_type)
+            await self._handle_new_connection(client)
+            return ws
+        except Error as e:
+            return web.Response(reason=e.reason, status=e.status)
+        finally:
+            if ws and not ws.closed:
+                await ws.close()
+                self.logger.debug("removing general websocket id: %s", ws_id)
+                if self.request.app['general_ws_clients'].get(ws_id):
+                    del self.request.app['general_ws_clients'][ws_id]
+
+    async def _handle_new_connection(self, client: GeneralWSClient) -> None:
+        async for msg in client.websocket:
+            # Ignore all messages from client
+            if msg.type == aiohttp.WSMsgType.text:
+                pass
+
+            elif msg.type == aiohttp.WSMsgType.error:
+                # 'client.websocket.exception()' merely returns ClientWebSocketResponse._exception
+                # without a traceback. see aiohttp.ws_client.py:receive for details.
+                self.logger.error('ws connection closed with exception %s',
+                                  client.websocket.exception())

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 
 import aiohttp
@@ -173,6 +174,7 @@ async def _subscribe_to_general_notifications_headers(api_token: str, expected_c
 
 async def _subscribe_to_general_notifications_peer_channels(url: str, api_token: str,
         expected_count: int, completion_event: asyncio.Event) -> None:
+    """Todo - Tests to assert that a different account_id does NOT receive messages it should not"""
     logger = logging.getLogger("test-general-notifications")
 
     count = 0
@@ -188,6 +190,11 @@ async def _subscribe_to_general_notifications_peer_channels(url: str, api_token:
                         content = json.loads(msg.data)
                         logger.info(f'New message: {content}')
                         assert content['message_type'] == 'bsvapi.channels.notification'
+                        assert isinstance(content['result'], Dict)
+                        assert isinstance(content['result']['id'], str)
+                        channel_id_bytes = base64.urlsafe_b64decode(content['result']['id'])
+                        assert len(channel_id_bytes) == 64
+                        assert content['result']['notification'] == 'New message arrived'
 
                         count += 1
                         if expected_count == count:

--- a/unittests/conftest.py
+++ b/unittests/conftest.py
@@ -1,20 +1,31 @@
+import logging
+
+import aiohttp
 import asyncio
 import json
 import os
 import sys
 import threading
 from pathlib import Path
-from typing import Optional
-import requests
+from typing import Optional, Union, Dict
+
+from _pytest.outcomes import Skipped
 from aiohttp.abc import Application
 from bitcoinx import PublicKey, PrivateKey
+import requests
+from aiohttp import WSServerHandshakeError
+
+from esv_reference_server.errors import WebsocketUnauthorizedException
 
 from server import AiohttpServer, logger, get_app
 
 TEST_HOST = "127.0.0.1"
 TEST_PORT = 52462
-WS_URL_TEMPLATE_MSG_BOX = "http://localhost:52462/api/v1/channel/{channelid}/notify"
+WS_URL_GENERAL = f"ws://localhost:{TEST_PORT}/api/v1/web-socket"
+WS_URL_HEADERS = f"ws://localhost:{TEST_PORT}/api/v1/headers/tips/websocket"
+WS_URL_TEMPLATE_MSG_BOX = "ws://localhost:52462/api/v1/channel/{channelid}/notify"
 
+REGTEST_GENESIS_BLOCK_HASH = "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
 PRIVATE_KEY_1 = PrivateKey.from_hex(
     "720f1987db69efa562b3dabd78e51f19bd8da76c70ad839b72b939f4071b144b")
 PUBLIC_KEY_1: PublicKey = PRIVATE_KEY_1.public_key
@@ -96,6 +107,102 @@ def _successful_call(url: str, method: str, headers: Optional[dict] = None,
     if good_bearer_token:
         headers["Authorization"] = f"Bearer {good_bearer_token}"
     return request_call(url, data=json.dumps(request_body), headers=headers)
+
+
+def _assert_header_structure(header: Dict) -> bool:
+    assert isinstance(header['hash'], str)
+    assert len(header['hash']) == 64
+    assert isinstance(header['version'], int)
+    assert isinstance(header['prevBlockHash'], str)
+    assert len(header['prevBlockHash']) == 64
+    assert isinstance(header['merkleRoot'], str)
+    assert len(header['merkleRoot']) == 64
+    assert isinstance(header['creationTimestamp'], int)
+    assert isinstance(header['difficultyTarget'], int)
+    assert isinstance(header['nonce'], int)
+    assert isinstance(header['transactionCount'], int)
+    assert isinstance(header['work'], int)
+    assert isinstance(header['work'], int)
+    return True
+
+
+def _assert_tip_structure_correct(tip: Dict) -> bool:
+    assert isinstance(tip, dict)
+    assert tip['header'] is not None
+    header = tip['header']
+    _assert_header_structure(header)
+    assert tip['state'] == 'LONGEST_CHAIN'
+    assert isinstance(tip['chainWork'], int)
+    assert isinstance(tip['height'], int)
+    assert isinstance(tip['confirmations'], int)
+    return True
+
+async def _subscribe_to_general_notifications_headers(api_token: str, expected_count: int,
+    completion_event: asyncio.Event) -> Union[bool, Skipped]:
+    logger = logging.getLogger("test-general-websocket-headers")
+
+    count = 0
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(WS_URL_GENERAL + f"?token={api_token}",
+                    timeout=5.0) as ws:
+                logger.info(f'Connected to {WS_URL_GENERAL}')
+
+                async for msg in ws:
+                    content = json.loads(msg.data)
+                    logger.info(f'New header notification: {content}')
+
+                    assert content['message_type'] == 'bsvapi.headers.tip'
+                    result = _assert_header_structure(content['result'])
+                    if not result:
+                        return False
+
+                    count += 1
+                    if count == expected_count:
+                        logger.info(f"Received {expected_count} headers successfully")
+                        completion_event.set()
+                        return result
+                    if msg.type in (aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                        break
+    except WSServerHandshakeError as e:
+        if e.status == 401:
+            raise WebsocketUnauthorizedException()
+    except Exception as e:
+        logger.exception("unexpected exception in _subscribe_to_general_notifications_headers")
+
+
+async def _subscribe_to_general_notifications_peer_channels(url: str, api_token: str,
+        expected_count: int, completion_event: asyncio.Event) -> None:
+    logger = logging.getLogger("test-general-notifications")
+
+    count = 0
+    async with aiohttp.ClientSession() as session:
+        try:
+            async with session.ws_connect(url + f"?token={api_token}",
+                                          timeout=5.0) as ws:
+
+                logger.info(f'Connected to {url}')
+                async for msg in ws:
+                    msg: aiohttp.WSMessage
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        content = json.loads(msg.data)
+                        logger.info(f'New message: {content}')
+                        assert content['message_type'] == 'bsvapi.channels.notification'
+
+                        count += 1
+                        if expected_count == count:
+                            logger.debug(f"Received all {expected_count} messages")
+                            await session.close()
+                            completion_event.set()
+                            return
+
+                    if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.ERROR,
+                                    aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
+                        logger.info("CLOSED")
+                        break
+        except WSServerHandshakeError as e:
+            if e.status == 401:
+                raise WebsocketUnauthorizedException()
 
 
 os.environ['EXPOSE_HEADER_SV_APIS'] = '1'

--- a/unittests/pytest.ini
+++ b/unittests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 log_format = %(asctime)s %(levelname)-8s %(name)-24s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
-log_cli=false
+log_cli=true
 log_level=DEBUG

--- a/unittests/test_peer_channels.py
+++ b/unittests/test_peer_channels.py
@@ -585,9 +585,10 @@ class TestAiohttpRESTAPI:
 
             completion_event = asyncio.Event()
             url = WS_URL_TEMPLATE_MSG_BOX.format(channelid=CHANNEL_ID)
-            asyncio.create_task(wait_on_sub(url, CHANNEL_BEARER_TOKEN, EXPECTED_MSG_COUNT, completion_event))
+            task1 = asyncio.create_task(wait_on_sub(url, CHANNEL_BEARER_TOKEN, EXPECTED_MSG_COUNT, completion_event))
             await asyncio.sleep(3)
-            asyncio.create_task(push_messages(CHANNEL_ID, CHANNEL_BEARER_TOKEN, EXPECTED_MSG_COUNT))
+            task2 = asyncio.create_task(push_messages(CHANNEL_ID, CHANNEL_BEARER_TOKEN, EXPECTED_MSG_COUNT))
+            await asyncio.gather(task1, task2)
             await completion_event.wait()
 
         asyncio.run(main())
@@ -641,11 +642,12 @@ class TestAiohttpRESTAPI:
 
             completion_event = asyncio.Event()
             url = WS_URL_GENERAL
-            asyncio.create_task(wait_on_sub(url, TEST_MASTER_BEARER_TOKEN, EXPECTED_MSG_COUNT,
+            task1 = asyncio.create_task(wait_on_sub(url, TEST_MASTER_BEARER_TOKEN, EXPECTED_MSG_COUNT,
                 completion_event))
             await asyncio.sleep(3)
-            asyncio.create_task(push_messages(CHANNEL_ID, CHANNEL_BEARER_TOKEN,
+            task2 = asyncio.create_task(push_messages(CHANNEL_ID, CHANNEL_BEARER_TOKEN,
                 EXPECTED_MSG_COUNT))
+            await asyncio.gather(task1, task2)
             await completion_event.wait()
 
         asyncio.run(main())

--- a/unittests/test_peer_channels.py
+++ b/unittests/test_peer_channels.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import aiohttp
-from aiohttp import web
+from aiohttp import web, WSServerHandshakeError
 from aiohttp.web_app import Application
 import base64
 from bitcoinx import PrivateKey, PublicKey
@@ -14,15 +14,15 @@ import threading
 from pathlib import Path
 import requests
 
-from esv_reference_server.errors import Error
+from esv_reference_server.errors import Error, WebsocketUnauthorizedException
 from esv_reference_server.sqlite_db import SQLiteDatabase
 from server import logger, AiohttpServer, get_app
 from unittests.conftest import _wrong_auth_type, _bad_token, _successful_call, _no_auth, \
-    API_ROUTE_DEFS, app
+    API_ROUTE_DEFS, app, WS_URL_GENERAL, _subscribe_to_general_notifications_peer_channels
 
 TEST_HOST = "127.0.0.1"
 TEST_PORT = 52462
-WS_URL_TEMPLATE_MSG_BOX = "http://localhost:52462/api/v1/channel/{channelid}/notify"
+WS_URL_TEMPLATE_MSG_BOX = "ws://localhost:52462/api/v1/channel/{channelid}/notify"
 
 PRIVATE_KEY_1 = PrivateKey.from_hex(
     "720f1987db69efa562b3dabd78e51f19bd8da76c70ad839b72b939f4071b144b")
@@ -510,30 +510,20 @@ class TestAiohttpRESTAPI:
         assert result.status_code == 404, result.reason
         assert result.reason is not None
 
-    def test_channels_websocket(self):
-        logger = logging.getLogger("websocket-test")
-        async def wait_on_sub(url: str, msg_box_api_token: str, expected_count: int, completion_event: asyncio.Event):
-            await subscribe_to_msg_box_notifications(url, msg_box_api_token, expected_count, completion_event)
+    async def _subscribe_to_msg_box_notifications(self, url: str, msg_box_api_token: str,
+            expected_count: int, completion_event: asyncio.Event) -> None:
 
-        async def subscribe_to_msg_box_notifications(url: str, msg_box_api_token: str,
-                expected_count: int, completion_event: asyncio.Event) -> None:
+        count = 0
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.ws_connect(url + f"?token={msg_box_api_token}", timeout=5.0) as ws:
 
-            count = 0
-            async with aiohttp.ClientSession() as session:
-                headers = {"Authorization": f"Bearer {msg_box_api_token}"}
-                async with session.ws_connect(url, headers=headers, timeout=5.0) as ws:
                     self.logger.info(f'Connected to {url}')
                     async for msg in ws:
                         msg: aiohttp.WSMessage
                         if msg.type == aiohttp.WSMsgType.TEXT:
                             content = json.loads(msg.data)
                             self.logger.info(f'New message from msg box: {content}')
-
-                            if isinstance(content, dict) and content.get('error'):
-                                error: Error = Error.from_websocket_dict(content)
-                                self.logger.info(f"Websocket error: {error}")
-                                if error.status == web.HTTPUnauthorized.status_code:
-                                    raise web.HTTPUnauthorized()
 
                             count += 1
                             if expected_count == count:
@@ -546,6 +536,31 @@ class TestAiohttpRESTAPI:
                                         aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
                             self.logger.info("CLOSED")
                             break
+            except WSServerHandshakeError as e:
+                if e.status == 401:
+                    raise WebsocketUnauthorizedException()
+
+
+    def test_channels_websocket_bad_auth_should_fail(self):
+        async def wait_on_sub(url: str, msg_box_api_token: str, expected_count: int, completion_event: asyncio.Event):
+            try:
+                await self._subscribe_to_msg_box_notifications(url, msg_box_api_token, expected_count, completion_event)
+            except WebsocketUnauthorizedException:
+                self.logger.debug(f"Websocket unauthorized - bad token")
+                assert True  # Auth should failed
+
+        completion_event = asyncio.Event()
+        url = WS_URL_TEMPLATE_MSG_BOX.format(channelid=CHANNEL_ID)
+        asyncio.run(wait_on_sub(url, "BAD_BEARER_TOKEN", 0, completion_event))
+
+    def test_channels_websocket(self):
+        logger = logging.getLogger("websocket-test")
+        async def wait_on_sub(url: str, msg_box_api_token: str, expected_count: int, completion_event: asyncio.Event):
+            try:
+                await self._subscribe_to_msg_box_notifications(url, msg_box_api_token, expected_count, completion_event)
+            except WebsocketUnauthorizedException:
+                self.logger.debug(f"Auth failed")
+                assert False  # Auth should have passed
 
         async def push_messages(CHANNEL_ID, CHANNEL_BEARER_TOKEN, expected_msg_count: int):
             for i in range(expected_msg_count):
@@ -573,6 +588,64 @@ class TestAiohttpRESTAPI:
             asyncio.create_task(wait_on_sub(url, CHANNEL_BEARER_TOKEN, EXPECTED_MSG_COUNT, completion_event))
             await asyncio.sleep(3)
             asyncio.create_task(push_messages(CHANNEL_ID, CHANNEL_BEARER_TOKEN, EXPECTED_MSG_COUNT))
+            await completion_event.wait()
+
+        asyncio.run(main())
+
+    def test_general_purpose_websocket_bad_auth_should_fail(self):
+        async def wait_on_sub(url: str, api_token: str,
+                              expected_count: int, completion_event: asyncio.Event):
+            try:
+                await _subscribe_to_general_notifications_peer_channels(url,
+                    api_token, expected_count, completion_event)
+            except WebsocketUnauthorizedException:
+                self.logger.debug(f"Websocket unauthorized - bad token")
+                assert True  # Auth should failed
+
+        completion_event = asyncio.Event()
+        url = WS_URL_GENERAL
+        asyncio.run(wait_on_sub(url, "BAD_BEARER_TOKEN", 0, completion_event))
+
+    def test_general_purpose_websocket_peer_channel_notifications(self):
+        logger = logging.getLogger("websocket-test")
+        async def wait_on_sub(url: str, api_token: str, expected_count: int,
+                completion_event: asyncio.Event):
+            try:
+                await _subscribe_to_general_notifications_peer_channels(
+                    url, api_token, expected_count, completion_event)
+            except WebsocketUnauthorizedException:
+                self.logger.debug(f"Auth failed")
+                assert False  # Auth should have passed
+
+        async def push_messages(CHANNEL_ID, CHANNEL_BEARER_TOKEN, expected_msg_count: int):
+            for i in range(expected_msg_count):
+                headers = {}
+                headers["Content-Type"] = "application/json"
+                headers["Authorization"] = f"Bearer {CHANNEL_BEARER_TOKEN}"
+                request_body = {"key": "value"}
+
+                url = f"http://127.0.0.1:{TEST_PORT}/api/v1/channel/{CHANNEL_ID}"
+
+                async with aiohttp.ClientSession() as session:
+                    headers = {"Authorization": f"Bearer {CHANNEL_BEARER_TOKEN}"}
+
+                    async with session.post(url, headers=headers, json=request_body) as resp:
+                        self.logger.debug(f"push_messages = {await resp.json()}")
+                        assert resp.status == 200, resp.reason
+
+        async def main():
+            EXPECTED_MSG_COUNT = 10
+            logger.debug(f"CHANNEL_ID: {CHANNEL_ID}")
+            logger.debug(f"CHANNEL_BEARER_TOKEN: {CHANNEL_BEARER_TOKEN}")
+            logger.debug(f"CHANNEL_READ_ONLY_TOKEN: {CHANNEL_READ_ONLY_TOKEN}")
+
+            completion_event = asyncio.Event()
+            url = WS_URL_GENERAL
+            asyncio.create_task(wait_on_sub(url, TEST_MASTER_BEARER_TOKEN, EXPECTED_MSG_COUNT,
+                completion_event))
+            await asyncio.sleep(3)
+            asyncio.create_task(push_messages(CHANNEL_ID, CHANNEL_BEARER_TOKEN,
+                EXPECTED_MSG_COUNT))
             await completion_event.wait()
 
         asyncio.run(main())


### PR DESCRIPTION
…l notifications

- It requires the master bearer token passed as a url query param (?token=<master token>).
- If auth fails it will send back 401 Unauthorized on initial connection
- It will notify of any notifications across all peer channels
- It will notify of any new tips
- Message structure is: {'message_type': "message type", 'result': 'result'}
- So far, only application/json is supported but a dedicated binary websocket will also be included
- Protocol versioning is based on the endpoint discovery apiVersion field. The responsibility for checking it is left to the client